### PR TITLE
Added description of the examples in the READMEs.

### DIFF
--- a/c/README.md
+++ b/c/README.md
@@ -8,17 +8,17 @@ The following simple examples are included in this repository:
 
 -  `test_event_handling`: Shows how to listen for events on a connection.
 
--  `test_get_records`: Shows how to obtain information on API objects such as 
+-  `test_get_records`: Shows how to obtain information on API objects such as
     hosts, VMs, and storage repositories.
 
 -  `test_failures`: Shows how to translate between error strings and
     `enum_xen_api_failure`.
 
--  `test_vm_async_migrate`: Shows how to use asynchronous API calls to migrate 
-    running VMs from a slave host to the pool master.
+-  `test_vm_async_migrate`: Shows how to use asynchronous API calls to migrate
+    running VMs from a supporter host to the pool coordinator.
 
--  `test_vm_ops`: Shows how to query the capabilities of a host, create a VM, 
-    attach a fresh blank disk image to the VM, and then perform various powercycle 
+-  `test_vm_ops`: Shows how to query the capabilities of a host, create a VM,
+    attach a fresh blank disk image to the VM, and then perform various powercycle
     operations.
 
 ## Dependencies

--- a/c/README.md
+++ b/c/README.md
@@ -1,5 +1,26 @@
 # libxenserver usage examples
 
+## Overview
+
+The following simple examples are included in this repository:
+
+-  `test_enumerate`: Shows how to enumerate the various API objects.
+
+-  `test_event_handling`: Shows how to listen for events on a connection.
+
+-  `test_get_records`: Shows how to obtain information on API objects such as 
+    hosts, VMs, and storage repositories.
+
+-  `test_failures`: Shows how to translate between error strings and
+    `enum_xen_api_failure`.
+
+-  `test_vm_async_migrate`: Shows how to use asynchronous API calls to migrate 
+    running VMs from a slave host to the pool master.
+
+-  `test_vm_ops`: Shows how to query the capabilities of a host, create a VM, 
+    attach a fresh blank disk image to the VM, and then perform various powercycle 
+    operations.
+
 ## Dependencies
 
 The examples need `libxenserver` which is dependent upon the

--- a/c/test_vm_async_migrate.c
+++ b/c/test_vm_async_migrate.c
@@ -82,7 +82,7 @@ static void usage()
             "    test_vm_async_migrate <url> <username> <password> <source-host> <target-host>\n"
             "\n"
             "where\n"
-            "    <url>          is the master server's URL, e.g. server.example.com\n"
+            "    <url>          is the coordinator server's URL, e.g. server.example.com\n"
             "    <username>     is the username to use at the server <url>\n"
             "    <password>     is the password to <url>.\n"
             "    <source-host>  is the name of the server to migrate all the VMs from\n"

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -1,5 +1,16 @@
 # XenServer.NET usage examples
 
+## Overview
+
+The XenServer.NET examples are shipped as a Microsoft Visual Studio solution.
+It includes the following files:
+
+-  `GetVariousRecords`: logs to a XenServer host and displays information about 
+    hosts, storage, and virtual machines.
+
+-  `VmPowerStates`: logs to a XenServer host, finds a VM and takes it through 
+    the various power states. Requires a shutdown VM to be already installed.
+
 ## How to run the examples
 
 Open `XenSdkSample.sln` inside Visual Studio 2022 and compile the solution.

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -5,10 +5,10 @@
 The XenServer.NET examples are shipped as a Microsoft Visual Studio solution.
 It includes the following files:
 
--  `GetVariousRecords`: logs to a XenServer host and displays information about 
+-  `GetVariousRecords`: logs into a XenServer host and displays information about
     hosts, storage, and virtual machines.
 
--  `VmPowerStates`: logs to a XenServer host, finds a VM and takes it through 
+-  `VmPowerStates`: logs to a XenServer host, finds a VM and takes it through
     the various power states. Requires a shutdown VM to be already installed.
 
 ## How to run the examples

--- a/java/README.md
+++ b/java/README.md
@@ -4,6 +4,35 @@ This folder contains of a number of test programs that can be used as pedagogica
 examples accompanying XenServerJava (com.xenserver.xen-api). They are
 structured as a Maven project.
 
+## Overview
+
+Running the main file `RunTests` runs a series of examples included in the 
+same directory:
+
+-  `AddNetwork`: Adds a new internal network not attached to any NICs.
+
+-  `AsyncVMCreate`: Makes asynchronously a new VM from a built-in template, 
+    starts, and stops it.
+
+-  `CreateVM`: Creates a VM on the default SR with a network and DVD drive.
+
+-  `EventMonitor`: Listens for events on a connection and prints each event out 
+    as it is received.
+
+-  `GetVariousRecords`: Retrieves the records for various types of objects.
+
+-  `SessionReuse`: Shows how a Session object can be shared among multiple Connections.
+
+-  `SharedStorage`: Creates a shared NFS SR.
+
+-  `StartAllVMs`: Connects to a host and tries to start each VM on it.
+
+-  `VMlifecycle`: Takes a VM through the various lifecycle states. Requires a 
+    shutdown VM with tools installed.
+
+-  `VdiAndSrOps`: Performs various SR and VDI tests, including creating
+    a dummy SR.
+
 ## Dependencies
 
 This code depends on XenServerJava, which in turns depends upon Apache XML-RPC

--- a/java/xen-api-samples/src/main/java/com/xensource/xenapi/samples/AsyncVMCreate.java
+++ b/java/xen-api-samples/src/main/java/com/xensource/xenapi/samples/AsyncVMCreate.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) Cloud Software Group, Inc.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   1) Redistributions of source code must retain the above copyright
  *      notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   2) Redistributions in binary form must reproduce the above
  *      copyright notice, this list of conditions and the following
  *      disclaimer in the documentation and/or other materials
  *      provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -49,8 +49,8 @@ public class AsyncVMCreate extends TestBase {
     }
 
     protected void TestCore() throws Exception {
-        /*First check we can start an HVM on the master*/
-        checkMasterHvmCapable();
+        /*First check we can start an HVM on the coordinator*/
+        checkCoordinatorHvmCapable();
 
         VM template = getFirstWindowsTemplate();
         log("Template found: " + template.getNameLabel(connection));

--- a/java/xen-api-samples/src/main/java/com/xensource/xenapi/samples/CreateVM.java
+++ b/java/xen-api-samples/src/main/java/com/xensource/xenapi/samples/CreateVM.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) Cloud Software Group, Inc.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   1) Redistributions of source code must retain the above copyright
  *      notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   2) Redistributions in binary form must reproduce the above
  *      copyright notice, this list of conditions and the following
  *      disclaimer in the documentation and/or other materials
  *      provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -48,8 +48,8 @@ public class CreateVM extends TestBase {
     }
 
     protected void TestCore() throws Exception {
-        /*First check we can start an HVM on the master*/
-        checkMasterHvmCapable();
+        /*First check we can start an HVM on the coordinator*/
+        checkCoordinatorHvmCapable();
 
         VM template = getFirstWindowsTemplate();
         log("Template found: " + template.getNameLabel(connection));

--- a/java/xen-api-samples/src/main/java/com/xensource/xenapi/samples/TestBase.java
+++ b/java/xen-api-samples/src/main/java/com/xensource/xenapi/samples/TestBase.java
@@ -202,13 +202,13 @@ public abstract class TestBase {
     }
 
     /**
-     * Checks whether the master has hvm capabilities.
+     * Checks whether the coordinator has hvm capabilities.
      */
-    protected void checkMasterHvmCapable() throws Exception {
-        log("checking master has hvm capabilities...");
+    protected void checkCoordinatorHvmCapable() throws Exception {
+        log("Checking coordinator has hvm capabilities...");
         Pool pool = (Pool) Pool.getAll(connection).toArray()[0];
-        Host master = pool.getMaster(connection);
-        Set<String> capabilities = master.getCapabilities(connection);
+        Host coordinator = pool.getMaster(connection);
+        Set<String> capabilities = coordinator.getCapabilities(connection);
 
         boolean hvmCapable = false;
         for (String s : capabilities)
@@ -218,6 +218,6 @@ public abstract class TestBase {
             }
 
         if (!hvmCapable)
-            throw new Exception("Master has no hvm capabilities!");
+            throw new Exception("Coordinator has no hvm capabilities!");
     }
 }

--- a/powershell/AutomatedTestCore.ps1
+++ b/powershell/AutomatedTestCore.ps1
@@ -301,7 +301,7 @@ function shutdown_vm([String]$vm_name) {
 
 # Host Functions
 
-function get_master() {
+function get_coordinator() {
     $pool = Get-XenPool
     return Get-XenHost -Ref $pool.master
 }
@@ -318,8 +318,8 @@ function get_default_sr() {
 
 function create_nfs_sr([String]$sr_svr, [String]$sr_path, [String]$sr_name) {
     log_info ("creating sr {0} at {1}:{2}" -f $sr_name, $sr_svr, $sr_path)
-    $master = get_master
-    $sr_opq = New-XenSR -XenHost $master -DeviceConfig @{ "server" = $sr_svr; "serverpath" = $sr_path; "options" = "" } `
+    $coordinator = get_coordinator
+    $sr_opq = New-XenSR -XenHost $coordinator -DeviceConfig @{ "server" = $sr_svr; "serverpath" = $sr_path; "options" = "" } `
         -PhysicalSize 0 -NameLabel $sr_name -NameDescription "" -Type "nfs" -ContentType "" `
         -Shared $true -SmConfig @{ } -Async -PassThru |`
         Wait-XenTask -ShowProgress -PassThru

--- a/powershell/README.md
+++ b/powershell/README.md
@@ -1,1 +1,10 @@
 # XenServer PowerShell Module usage examples
+
+## Overview
+
+-  `AutomatedTestCore.ps1`: Shows how to log into a host, create a storage 
+    repository and a VM, and then perform various powercycle operations.
+
+-  `HttpTest.ps1`: Shows how to log into a host, create a VM, and then perform 
+    operations such as VM importing and exporting, patch upload, and retrieval 
+    of performance statistics.

--- a/python/README.md
+++ b/python/README.md
@@ -1,5 +1,31 @@
 # XenAPI.py usage examples
 
+## Overview
+
+The following Python examples are included in this repository:
+
+-  `fixpbds.py` - reconfigures the settings used to access shared storage.
+
+-  `install.py` - installs a Debian VM, connects it to a network, starts it up and 
+    waits for it to report its IP address.
+
+-  `license.py` - uploads a fresh license to a XenServer host.
+
+-  `permute.py` - selects a set of VMs and uses live migration to move them
+    simultaneously among hosts.
+
+-  `powercycle.py` - selects a set of VMs and powercycles them.
+
+-  `provision.py`: - parses/regenerates the "disk provisioning" XML contained 
+    within templates
+
+-  `shutdown.py`: - shows how to prepare and shutdown a host.
+
+-  `vm_start_async.py` - shows how to invoke operations asynchronously.
+
+-  `watch-all-events.py` - registers for all events and prints details
+    when they occur.
+
 ## How to run the scripts
 
 Each script requires 3 command line arguments:

--- a/python/shutdown.py
+++ b/python/shutdown.py
@@ -258,15 +258,15 @@ if __name__ == "__main__":
 
     new_session = XenAPI.xapi_local()
 
-    connect_to_master_with_timeout = TimeoutFunction(new_session.xenapi.login_with_password, TIMEOUT_SECS)
+    connect_to_coordinator_with_timeout = TimeoutFunction(new_session.xenapi.login_with_password, TIMEOUT_SECS)
 
     try:
-        connect_to_master_with_timeout("root", "")
+        connect_to_coordinator_with_timeout("root", "")
     except TimeoutFunctionException:
-        print "Unable to connect to master within %d seconds. Exiting." % TIMEOUT_SECS
+        print "Unable to connect to coordinator within %d seconds. Exiting." % TIMEOUT_SECS
         sys.exit(1)
     except Exception:
-        print 'Failed to connect to master.'
+        print 'Failed to connect to coordinator.'
         sys.exit(2)
 
     try:


### PR DESCRIPTION
This is info that I'm removing from the SDK guide. It's easier to manage if it's closer where the example code actually resides.