### PR TITLE
CA-387821: SDK Tests/JavaSDK failed. Set Network.managed to true befo…

### DIFF
--- a/java/xen-api-samples/src/main/java/com/xensource/xenapi/samples/AddNetwork.java
+++ b/java/xen-api-samples/src/main/java/com/xensource/xenapi/samples/AddNetwork.java
@@ -47,6 +47,7 @@ public class AddNetwork extends TestBase {
         Date newDate = new Date();
         networkRecord.nameLabel = "TestNetwork-" + newDate;
         networkRecord.nameDescription = "Created by AddNetwork.java at " + newDate;
+        networkRecord.managed = true;
 
         log("Adding new network: " + networkRecord.nameLabel);
         Network.create(connection, networkRecord);


### PR DESCRIPTION
The default for `managed` should be true, but the default in Java SDK is false.
 The Java SDK is auto-generated, so it's hard to change the default value.
So change the default in the sample.