### PR TITLE
Remove `-DgeneratePom` from Java's `README`

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -42,7 +42,7 @@ by the Apache Software Foundation, licensed under the Apache Software License 2.
 If you have the jar, you can install it using the Maven CLI:
 
 ```bash
-mvn install:install-file -Dfile=".\xen-api-XX.YY.ZZ.jar" -DgroupId="com.xenserver" -DartifactId=xen-api -Dversion="XX.YY.ZZ" -Dpackaging=jar -DgeneratePom=true
+mvn install:install-file -Dfile=".\xen-api-XX.YY.ZZ.jar" -DgroupId="com.xenserver" -DartifactId=xen-api -Dversion="XX.YY.ZZ" -Dpackaging=jar
 ```
 
 ## How to run the tests


### PR DESCRIPTION
The option generates a minimal `pom.xml` that isn't needed for `xen-api.jar`. Using a minimal POM also breaks checks for transitive dependencies